### PR TITLE
[RFC] v4l2_m2m_dec: Don't enforce lockstep input and output

### DIFF
--- a/libavcodec/v4l2_m2m.h
+++ b/libavcodec/v4l2_m2m.h
@@ -103,9 +103,6 @@ typedef struct V4L2m2mContext {
 
     pts_stats_t pts_stat;
 
-    /* req pkt */
-    int req_pkt;
-
     /* Ext data sent */
     int extdata_sent;
 } V4L2m2mContext;

--- a/libavcodec/v4l2_m2m_dec.c
+++ b/libavcodec/v4l2_m2m_dec.c
@@ -425,13 +425,6 @@ static int v4l2_receive_frame(AVCodecContext *avctx, AVFrame *frame)
     do {
         src_rv = try_enqueue_src(avctx, s);
 
-        // If we got a frame last time and we have nothing to enqueue then
-        // return now. rv will be AVERROR(EAGAIN) indicating that we want more input
-        // This should mean that once decode starts we enter a stable state where
-        // we alternately ask for input and produce output
-        if (s->req_pkt && src_rv == NQ_SRC_EMPTY)
-            break;
-
         if (src_rv == NQ_Q_FULL && dst_rv == AVERROR(EAGAIN)) {
             av_log(avctx, AV_LOG_WARNING, "Poll says src Q has space but enqueue fail");
             src_rv = NQ_SRC_EMPTY;  // If we can't enqueue pretend that there is nothing to enqueue
@@ -469,9 +462,6 @@ static int v4l2_receive_frame(AVCodecContext *avctx, AVFrame *frame)
     // (might happen when discarding)
     if (dst_rv)
         av_frame_unref(frame);
-
-    // If we got a frame this time ask for a pkt next time
-    s->req_pkt = (dst_rv == 0);
 
 #if 0
     if (dst_rv == 0)


### PR DESCRIPTION
Enforcing this 1:1 input to output ratio prevents draining excess decoded frames that build up during initialization while waiting for the first output frame. This is because a 1:0 input to output ratio occurs while the decoder is warming up prior to the first output frame.

An additional frame of latency accumulates each time a packet is submitted and `avcodec_receive_frame()` returns `AVERROR(EAGAIN)` due to having no output frame ready yet. It's impossible to drain these excess frames because we can't receive more than one frame per enqueued packet.