### PR TITLE
dmabufs: don't call buf_free() if buffer has no functions

### DIFF
--- a/libavcodec/v4l2_req_dmabufs.c
+++ b/libavcodec/v4l2_req_dmabufs.c
@@ -232,7 +232,8 @@ void dmabuf_free(struct dmabuf_h * dh)
     request_log("%s: Free: %zd, total=%zd, bufs=%d\n", __func__, dh->size, total_size, total_bufs);
 #endif
 
-    dh->fns->buf_free(dh);
+    if (dh->fns)
+        dh->fns->buf_free(dh);
 
     if (dh->mapptr != MAP_FAILED && dh->mapptr != NULL)
         munmap(dh->mapptr, dh->size);


### PR DESCRIPTION
A dmabuf_h can have no functions if it's created through dmabuf_import() or dmabuf_import_mmap(). In those cases, a simple munmap() and/or close() should handle them just fine.

---

This fixes playing this HEVC-encoded video, where ffmpeg re-initializes HW acceleration a few times:

https://github.com/jc-kynesim/rpi-ffmpeg/assets/6771175/b5cf97b7-d4c2-4f73-976f-301f71ececd1



