### PR TITLE
rtpenc: Fix building with GCC 14

### DIFF
--- a/libavformat/rtpenc.c
+++ b/libavformat/rtpenc.c
@@ -587,7 +587,7 @@ static int rtp_write_packet(AVFormatContext *s1, AVPacket *pkt)
     case AV_CODEC_ID_H264:
     {
         uint8_t *side_data;
-        int side_data_size = 0;
+        size_t side_data_size = 0;
 
         side_data = av_packet_get_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
                                             &side_data_size);


### PR DESCRIPTION
This incompatible pointer type issue became a fatal error in GCC 14. The AVBuffer API started using `size_t` in 5.0 with ef6a9e5e.