### PR TITLE
v4l2_req_media: let media_request takes reference of media_pool

### DIFF
--- a/libavcodec/v4l2_req_media.h
+++ b/libavcodec/v4l2_req_media.h
@@ -49,7 +49,8 @@ typedef enum media_buf_status {
 struct media_pool * media_pool_new(const char * const media_path,
                    struct pollqueue * const pq,
                    const unsigned int n);
-void media_pool_delete(struct media_pool ** pmp);
+struct media_pool * media_pool_ref(struct media_pool * mp);
+void media_pool_unref(struct media_pool ** pmp);
 
 // Obtain a media request
 // Will block if none availible - has a 2sec timeout

--- a/libavcodec/v4l2_request_hevc.c
+++ b/libavcodec/v4l2_request_hevc.c
@@ -103,7 +103,7 @@ static int v4l2_request_hevc_uninit(AVCodecContext *avctx)
     decode_q_wait(&ctx->decode_q, NULL);  // Wait for all other threads to be out of decode
 
     mediabufs_ctl_unref(&ctx->mbufs);
-    media_pool_delete(&ctx->mpool);
+    media_pool_unref(&ctx->mpool);
     pollqueue_unref(&ctx->pq);
     dmabufs_ctl_unref(&ctx->dbufs);
     devscan_delete(&ctx->devscan);
@@ -323,7 +323,7 @@ fail5:
 fail4:
     mediabufs_ctl_unref(&ctx->mbufs);
 fail3:
-    media_pool_delete(&ctx->mpool);
+    media_pool_unref(&ctx->mpool);
 fail2:
     pollqueue_unref(&ctx->pq);
 fail1:


### PR DESCRIPTION
This prevents media_pool from being freed before all requests are
returned to it.

Fixes: #78