### PR TITLE
Resolving Incompatible Pointer Types Error when compiling using gcc14

### DIFF
--- a/libavformat/rtpenc.c
+++ b/libavformat/rtpenc.c
@@ -587,7 +587,7 @@ static int rtp_write_packet(AVFormatContext *s1, AVPacket *pkt)
     case AV_CODEC_ID_H264:
     {
         uint8_t *side_data;
-        int side_data_size = 0;
+        size_t side_data_size = 0;
 
         side_data = av_packet_get_side_data(pkt, AV_PKT_DATA_NEW_EXTRADATA,
                                             &side_data_size);


### PR DESCRIPTION
I'm submitting this pull request to fix the following error when I try to build `rpi-ffmpeg` using gcc14:
```c
libavformat/rtpenc.c: In function 'rtp_write_packet':
libavformat/rtpenc.c:593:45: error: passing argument 3 of 'av_packet_get_side_data' from incompatible pointer type [-Wincompatible-pointer-types]
593 | &side_data_size);
    | ^~~~~~~~~~~~~~~
    | |
    | int *
In file included from libavformat/avformat.h:316,
from libavformat/rtpenc.c:23:
./libavcodec/packet.h:604:42: note: expected 'size_t *' {aka 'long unsigned int *'} but argument is of type 'int *'
604 | size_t *size);
    | ~~~~~~~~^~~~
```