### PR TITLE
Add stateful AV1 decode support

### DIFF
--- a/configure
+++ b/configure
@@ -3424,6 +3424,7 @@ av1_nvenc_encoder_select="atsc_a53"
 av1_qsv_decoder_select="qsvdec"
 av1_qsv_encoder_deps="libvpl"
 av1_qsv_encoder_select="qsvenc"
+av1_v4l2m2m_decoder_deps="v4l2_m2m av1_v4l2_m2m"
 av1_vaapi_encoder_deps="VAEncPictureParameterBufferAV1"
 av1_vaapi_encoder_select="cbs_av1 vaapi_encode"
 av1_vulkan_encoder_deps="vulkan_1_4"
@@ -7402,6 +7403,7 @@ if enabled v4l2_m2m; then
     check_cc h264_v4l2_m2m linux/videodev2.h "int i = V4L2_PIX_FMT_H264;"
     check_cc vp8_v4l2_m2m linux/videodev2.h "int i = V4L2_PIX_FMT_VP8;"
     check_cc vp9_v4l2_m2m linux/videodev2.h "int i = V4L2_PIX_FMT_VP9;"
+    check_cc av1_v4l2_m2m linux/videodev2.h "int i = V4L2_PIX_FMT_AV1;"
 fi
 
 check_func_headers "linux/media.h linux/videodev2.h" v4l2_timeval_to_ns

--- a/libavcodec/allcodecs.c
+++ b/libavcodec/allcodecs.c
@@ -853,6 +853,7 @@ extern const FFCodec ff_av1_qsv_encoder;
 extern const FFCodec ff_av1_amf_encoder;
 extern const FFCodec ff_av1_amf_decoder;
 extern const FFCodec ff_av1_mf_encoder;
+extern const FFCodec ff_av1_v4l2m2m_decoder;
 extern const FFCodec ff_av1_vaapi_encoder;
 extern const FFCodec ff_av1_vulkan_encoder;
 extern const FFCodec ff_libopenh264_encoder;

--- a/libavcodec/v4l2_context.c
+++ b/libavcodec/v4l2_context.c
@@ -502,7 +502,7 @@ dq_buf(V4L2Context * const ctx, V4L2Buffer ** const ppavbuf)
             // buffers but better to be tidy.
             ff_v4l2_buffer_enqueue(avbuf);
 
-            ctx->flag_last = 1;
+            // ctx->flag_last = 1; // XXX: breaks av1, doesn't seem necessary?
             return AVERROR(EPIPE);
         }
 

--- a/libavcodec/v4l2_fmt.c
+++ b/libavcodec/v4l2_fmt.c
@@ -112,6 +112,9 @@ static const struct fmt_conversion {
 #ifdef V4L2_PIX_FMT_HEVC
     { AV_FMT(NONE),        AV_CODEC(HEVC),        V4L2_FMT(HEVC) },
 #endif
+#ifdef V4L2_PIX_FMT_AV1
+    { AV_FMT(NONE),        AV_CODEC(AV1),         V4L2_FMT(AV1) },
+#endif
 #ifdef V4L2_PIX_FMT_VC1_ANNEX_G
     { AV_FMT(NONE),        AV_CODEC(VC1),         V4L2_FMT(VC1_ANNEX_G) },
 #endif

--- a/libavcodec/v4l2_m2m_dec.c
+++ b/libavcodec/v4l2_m2m_dec.c
@@ -1442,3 +1442,4 @@ M2MDEC(h263,  "H.263", AV_CODEC_ID_H263,       NULL);
 M2MDEC(vc1 ,  "VC1",   AV_CODEC_ID_VC1,        NULL);
 M2MDEC(vp8,   "VP8",   AV_CODEC_ID_VP8,        NULL);
 M2MDEC(vp9,   "VP9",   AV_CODEC_ID_VP9,        NULL);
+M2MDEC(av1,   "AV1",   AV_CODEC_ID_AV1,        NULL);


### PR DESCRIPTION
The UAPI bits are not defined upstream yet but will be when [this series](https://lore.kernel.org/all/20251210-av1d_stateful_v3-v10-0-cf4379a3dcff@oss.qualcomm.com/) lands (that also introduces the first decoder that supports it)..

The interesting thing is the `flag_last` issue, without removing that place that sets it, I only see the first frame and:

```
[av1 @ 0xffff7b1ff6c0] Frame 31:  size 854x480  upscaled 854  render 854x480  subsample 2x2  bitdepth 8  tiles 2x2.
[av1_v4l2m2m @ 0xffff7b1ffeb0] capture: Buffer requeue
[av1_v4l2m2m @ 0xffff7b1ffeb0] --- capture VIDIOC_QBUF: index 0, ts=0.000015 count=20
[av1_v4l2m2m @ 0xffff7b1ffeb0] Pending=6, src_rv=-1, req_pkt=1
[av1_v4l2m2m @ 0xffff7b1ffeb0] V4L2 poll capture ret=1, timeout=5, events=0x41, revents=0x41
[av1_v4l2m2m @ 0xffff7b1ffeb0] --- capture VIDIOC_QBUF: index 1, ts=0.000000 count=20
video: delay=0.040 A-V=nan
[av1_v4l2m2m @ 0xffff7b1ffeb0] V4L2 poll capture ret=0, timeout=5, events=0x2, revents=0
[av1_v4l2m2m @ 0xffff7b1ffeb0] V4L2 capture poll event timeout
[av1_v4l2m2m @ 0xffff7b1ffeb0] V4L2 VIDIOC_DQEVENT: No such file or directory
[av1_v4l2m2m @ 0xffff7b1ffeb0] Packet dequeue failure: draining=0, cap.done=1, err=-2
[av1_v4l2m2m @ 0xffff7b1ffeb0] Pending=6, src_rv=-1, req_pkt=0
[av1_v4l2m2m @ 0xffff7b1ffeb0] V4L2 capture already done
[av1_v4l2m2m @ 0xffff7b1ffeb0] Dequeue EOF: draining=0, cap.done=1
[av1_v4l2m2m @ 0xffff7b1ffeb0] <<< v4l2_decode_flush: streamon=1
[av1_v4l2m2m @ 0xffff7b1ffeb0] output set status OFF OK
[av1_v4l2m2m @ 0xffff7b1ffeb0] capture set status OFF OK
[av1_v4l2m2m @ 0xffff7b1ffeb0] --- capture pre VIDIOC_QBUF: index 0, ts=0.000015 count=0
[av1_v4l2m2m @ 0xffff7b1ffeb0] --- capture VIDIOC_QBUF: index 0, ts=0.000000 count=1 [.....]
[av1_v4l2m2m @ 0xffff7b1ffeb0] --- capture VIDIOC_QBUF: index 19, ts=0.000000 count=20
[av1_v4l2m2m @ 0xffff7b1ffeb0] capture set status ON OK
[av1_v4l2m2m @ 0xffff7b1ffeb0] >>> v4l2_decode_flush
[av1_v4l2m2m @ 0xffff7b1ffeb0] Pending=-16, src_rv=-1, req_pkt=0
[av1_v4l2m2m @ 0xffff7b1ffeb0] try_enqueue_src: receive_frame before 1st coded packet
[av1_v4l2m2m @ 0xffff7b1ffeb0] Pending=-16, src_rv=-1, req_pkt=0
[av1_v4l2m2m @ 0xffff7b1ffeb0] output set status ON OK
[av1_v4l2m2m @ 0xffff7b1ffeb0] VIDIOC_DECODER_CMD start error: Resource busy
[av1_v4l2m2m @ 0xffff7b1ffeb0] V4L2 poll output empty
```

and that `VIDIOC_DQEVENT` should not be invoked, we should just continue and it all plays fine.